### PR TITLE
Assign NULL to metadata & group_name if not provided in config

### DIFF
--- a/Scripts/findAAChanges.R
+++ b/Scripts/findAAChanges.R
@@ -45,6 +45,9 @@ reference.path = paste0(gsub("\"", "", config$OUTPUT_DIRECTORY),"/reference.fa")
 
 #Optional for merging metadata with AA data, set to NULL if none available
 metadata.file = gsub("\"", "", config$METADATA)
+if(length(metadata.file) == 0L) {
+  metadata.file <- NULL
+}
 
 #Set multithreading and memory usage
 threads = as.numeric(gsub("\"", "", config$THREADS))

--- a/Scripts/outputSummary.R
+++ b/Scripts/outputSummary.R
@@ -35,6 +35,9 @@ output.directory = paste0(gsub("\"", "", config$OUTPUT_DIRECTORY), "/variant_ana
 #Grouping category column name joined in step 2 with the variant sample data
 #Set to NULL if there are no groupings to use
 group.names = gsub("\"", "", config$GROUP_NAMES)
+if(length(group.names) == 0L) {
+  group.names <- NULL
+}
 
 #############################################
 #### Should not need to modify below here


### PR DESCRIPTION
Script fails to finish when METADATA & GROUP_NAMES are not defined in the config file. With this code, we can now comment out those fields in the config file and the script will set them to NULL. The NULL checks then act as expected in the downstream code.