### PR TITLE
Bug fix for reference name not matching 'reference.fa'

### DIFF
--- a/Flumina
+++ b/Flumina
@@ -50,7 +50,7 @@ else
 fi
 
 #Copies reference to output directory so snakefile can find it
-cp "$REFERENCE_FILE" "$OUTPUT_DIRECTORY"
+cp "$REFERENCE_FILE" "$OUTPUT_DIRECTORY"/reference.fa
 
 #Export variable to global env
 export CLUSTER_JOBS


### PR DESCRIPTION
When using a new reference, it fails to complete if the reference name is not 'reference.fa'. I altered the cp statement so that when it copies, it saves as 'reference.fa'. 

I don't like having to rename the reference to something generic, especially since the fasta headers can't have any extra identifiers in them either (just gene names), but it's a bandaid fix for now.